### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==1.1.2
 Flask-JWT-Extended==3.25.0
 flask_login
 Flask-WTF
-flask-ldap3-login==0.9.16
+flask-ldap3-login==0.9.17
 python-i18n==0.3.9
 werkzeug==0.16.1
 qwc-services-core==1.2.4


### PR DESCRIPTION
Hi,
I tried to run the latest image "sourcepole/qwc-ldap-auth:v2021.12.17" But there is an error on startup of the container.
```
...
qwc-ldap-service_1             | *** Operational MODE: threaded ***
qwc-ldap-service_1             | mounting server:app on /ldap
qwc-ldap-service_1             | Traceback (most recent call last):
qwc-ldap-service_1             |   File "/srv/qwc_service/./server.py", line 17, in <module>
qwc-ldap-service_1             |     from flask_ldap3_login.forms import LDAPLoginForm
qwc-ldap-service_1             |   File "/usr/lib/python3.8/site-packages/flask_ldap3_login/forms.py", line 15, in <module>
qwc-ldap-service_1             |     class LDAPLoginForm(FlaskForm):
qwc-ldap-service_1             |   File "/usr/lib/python3.8/site-packages/flask_ldap3_login/forms.py", line 26, in LDAPLoginForm
qwc-ldap-service_1             |     username = wtforms.StringField('Username', validators=[validators.Required()])
qwc-ldap-service_1             | AttributeError: module 'wtforms.validators' has no attribute 'Required'
qwc-ldap-service_1             | unable to load app 0 (mountpoint='/ldap') (callable not found or import error)
qwc-ldap-service_1             | *** no app loaded. going in full dynamic mode ***
qwc-ldap-service_1             | *** uWSGI is running in multiple interpreter mode ***
...
```
There seems to be a bug in the 'flask-ldap3-login' package; See here for reference https://github.com/nickw444/flask-ldap3-login/issues/97

Updating 'flask-ldap3-login' to version 0.9.17 fixes this issue.